### PR TITLE
release 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,58 +6,67 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- insertion marker -->
+## [0.13.1](https://github.com/georgedouzas/sports-betting/releases/tag/0.13.1) - 2026-07-10
+
+<small>[Compare with 0.13.0](https://github.com/georgedouzas/sports-betting/compare/0.13.0...0.13.1)</small>
+
+### Bug Fixes
+
+- Drop nptyping so numpy can move to 2.x ([a8944b3](https://github.com/georgedouzas/sports-betting/commit/a8944b33b4d417c9cede840fb668ffae6eb0fce3) by georgedouzas).
+
 ## [0.13.0](https://github.com/georgedouzas/sports-betting/releases/tag/0.13.0) - 2026-07-10
 
 <small>[Compare with 0.12.1](https://github.com/georgedouzas/sports-betting/compare/0.12.1...0.13.0)</small>
 
 ### Features
 
-- Add an input horizon and factory construction functions ([4e9bfe7](https://github.com/georgedouzas/sports-betting/commit/4e9bfe755bf8e6207535c65d0e0a332104236cdb) by georgedouzas).
-- Expose target moment in CLI and GUI ([c926886](https://github.com/georgedouzas/sports-betting/commit/c9268864e391ea3af9e653914c063956d49c79a9) by georgedouzas).
-- Adapt bettors to moment-aware X/Y/O ([c2f42b9](https://github.com/georgedouzas/sports-betting/commit/c2f42b919163e72e4053dc0c66a208d51266bcbc) by georgedouzas).
-- Add soccer and offline dummy snapshot dataloaders ([86381e6](https://github.com/georgedouzas/sports-betting/commit/86381e65ba4d9004f00727cee2618b6b365f1c02) by georgedouzas).
-- Add moment-aware event-snapshot data model ([21d23ce](https://github.com/georgedouzas/sports-betting/commit/21d23ced6d1f4e3010be253948dfa87242c9163c) by georgedouzas).
-- Validate pandas schema ([b2b1f21](https://github.com/georgedouzas/sports-betting/commit/b2b1f21fbadaca4df714c09f6fa7a9b408509d90) by georgedouzas).
-- Modify base class ([214e0c4](https://github.com/georgedouzas/sports-betting/commit/214e0c477bf6afb177fbb3628a9affc8e9e20b8d) by georgedouzas).
+- Add an input horizon and factory construction functions ([a04a0c8](https://github.com/georgedouzas/sports-betting/commit/a04a0c80174d082e0e10fd2ec82c86afa89476c5) by georgedouzas).
+- Expose target moment in CLI and GUI ([364d7b0](https://github.com/georgedouzas/sports-betting/commit/364d7b0fea2541958bd23f2cf879b601ef39c3d4) by georgedouzas).
+- Adapt bettors to moment-aware X/Y/O ([d33d330](https://github.com/georgedouzas/sports-betting/commit/d33d3301fbfa3e6b472e5c1656b1d1671d297754) by georgedouzas).
+- Add soccer and offline dummy snapshot dataloaders ([c4dda0b](https://github.com/georgedouzas/sports-betting/commit/c4dda0b59b355a0d08e07dbaabec24b1833446fd) by georgedouzas).
+- Add moment-aware event-snapshot data model ([d2237da](https://github.com/georgedouzas/sports-betting/commit/d2237dacd93f70410fa299ed06b9ed024f234098) by georgedouzas).
+- Validate pandas schema ([05470ca](https://github.com/georgedouzas/sports-betting/commit/05470ca484815307d2bafeb78ebd5803395502ac) by georgedouzas).
+- Modify base class ([9fcdb3c](https://github.com/georgedouzas/sports-betting/commit/9fcdb3cc79702c4e01a89fe79f5339f516f11142) by georgedouzas).
 
 ### Bug Fixes
 
-- Pass the full odds data to bet when scoring ([986f050](https://github.com/georgedouzas/sports-betting/commit/986f050d30eae9c39e3fef4a4a443e61719b9235) by georgedouzas).
-- Discover feed parameters from a manifest ([b068e9c](https://github.com/georgedouzas/sports-betting/commit/b068e9c9cbc12e46dc369e34799f1185bf211602) by georgedouzas).
-- Make the soccer feed robust to empty fixtures ([e35401f](https://github.com/georgedouzas/sports-betting/commit/e35401faad32b747503e783ab9647973982ecb22) by georgedouzas).
+- Pass the full odds data to bet when scoring ([d92f245](https://github.com/georgedouzas/sports-betting/commit/d92f245cdf6d99b9049896ea43c3da5e23cce0c1) by georgedouzas).
+- Discover feed parameters from a manifest ([1631b4f](https://github.com/georgedouzas/sports-betting/commit/1631b4f3363e7496ecd5627dbbf8057dc4657bfa) by georgedouzas).
+- Make the soccer feed robust to empty fixtures ([f4f59e6](https://github.com/georgedouzas/sports-betting/commit/f4f59e6d69d8573dfa30d3d8c3bd7ad8127d990b) by georgedouzas).
 
 ### Docs
 
-- Fix stale betting_markets grammar in the README ([2b1d1aa](https://github.com/georgedouzas/sports-betting/commit/2b1d1aa75c849ad2ae73a8fc3022cbd3a737c0a8) by georgedouzas).
-- Document all bettor parameters and the grid search ([43dba56](https://github.com/georgedouzas/sports-betting/commit/43dba5697d1428bad0547942f9b8bb3404571bf8) by georgedouzas).
-- Fix the ambiguous user-guide cross-reference ([6b389d4](https://github.com/georgedouzas/sports-betting/commit/6b389d4cd38aad79aa87ce1bf83f9b12c22596ab) by georgedouzas).
-- Expand the dataloader guide and add an end-to-end guide ([f7a3252](https://github.com/georgedouzas/sports-betting/commit/f7a3252169f1716039b3f15222903768aec3ff95) by georgedouzas).
-- Document long-format snapshots and consumption ([9983571](https://github.com/georgedouzas/sports-betting/commit/998357158d220c4a9547e29aeb0189a8310d9ef8) by georgedouzas).
-- Use market_average provider in bettor examples ([b6c77af](https://github.com/georgedouzas/sports-betting/commit/b6c77afc964e7f1625aa3d8b10755dede8cd583d) by georgedouzas).
-- Align spec-kit gate docs with copier update ([4ddcb18](https://github.com/georgedouzas/sports-betting/commit/4ddcb181dc163b3f9e7e0c90ac61b9aae3f6b3e7) by georgedouzas).
-- Update guides and changelog for in-play model ([21ea968](https://github.com/georgedouzas/sports-betting/commit/21ea96856263b47102dd1d8d7a940c8c38cd834c) by georgedouzas).
+- Fix stale betting_markets grammar in the README ([7864397](https://github.com/georgedouzas/sports-betting/commit/7864397b9eb4682a4c6e3d77c90fc092f8066f25) by georgedouzas).
+- Document all bettor parameters and the grid search ([82226c3](https://github.com/georgedouzas/sports-betting/commit/82226c3c1f51e8022c42b5933b616f37a9535b77) by georgedouzas).
+- Fix the ambiguous user-guide cross-reference ([16737ed](https://github.com/georgedouzas/sports-betting/commit/16737edab72d7674f220a1250d2990fe08a6f88a) by georgedouzas).
+- Expand the dataloader guide and add an end-to-end guide ([9ee55ea](https://github.com/georgedouzas/sports-betting/commit/9ee55ea12e00763b63a768dee75b49407d561133) by georgedouzas).
+- Document long-format snapshots and consumption ([6b1dbae](https://github.com/georgedouzas/sports-betting/commit/6b1dbaef969f17babbf71018522b027d35bc382f) by georgedouzas).
+- Use market_average provider in bettor examples ([090ec29](https://github.com/georgedouzas/sports-betting/commit/090ec29578bca6fa641e9e215915250bcf9106e1) by georgedouzas).
+- Align spec-kit gate docs with copier update ([ef602ec](https://github.com/georgedouzas/sports-betting/commit/ef602ec105bdb74aac1e3103e2938cfabea5f16f) by georgedouzas).
+- Update guides and changelog for in-play model ([1cbc2b0](https://github.com/georgedouzas/sports-betting/commit/1cbc2b0bf11ab042959bf66543f9e7839917cb44) by georgedouzas).
 
 ### Code Refactoring
 
-- Drop the test-only engine helper from source ([7b67140](https://github.com/georgedouzas/sports-betting/commit/7b67140d0ab3ef9eee8f8f2da51c5da9ed8e6936) by georgedouzas).
-- Move the factory functions to a dedicated module ([99b8289](https://github.com/georgedouzas/sports-betting/commit/99b82894c1d4a8da87e36eac8fdc52414139ffae) by georgedouzas).
-- Make BaseDataLoader abstract and drop from_csv ([0cc738e](https://github.com/georgedouzas/sports-betting/commit/0cc738e71a7320d8d872fd556f696d4a047d37eb) by georgedouzas).
-- Make all dataloaders inherit BaseDataLoader directly ([9bb32e5](https://github.com/georgedouzas/sports-betting/commit/9bb32e5edfeaf4de4e5a766ac4db6e11f301841b) by georgedouzas).
-- Read long-format snapshots and derive schemas ([de8ecbb](https://github.com/georgedouzas/sports-betting/commit/de8ecbb065238ea39b5b47f4e3c58c96c675c9b2) by georgedouzas).
-- Simplify comments and constants ([0c662f0](https://github.com/georgedouzas/sports-betting/commit/0c662f03066aab4c7bb247c756bfeb1718c9c816) by georgedouzas).
+- Drop the test-only engine helper from source ([506af4b](https://github.com/georgedouzas/sports-betting/commit/506af4b677ed42318b43e7f41b212c2f4c5b517b) by georgedouzas).
+- Move the factory functions to a dedicated module ([12a6936](https://github.com/georgedouzas/sports-betting/commit/12a69361559cea121e134a98d68c5b68b36d3098) by georgedouzas).
+- Make BaseDataLoader abstract and drop from_csv ([946b61a](https://github.com/georgedouzas/sports-betting/commit/946b61acd439b51f17d9d950250b006b079cba77) by georgedouzas).
+- Make all dataloaders inherit BaseDataLoader directly ([6f73027](https://github.com/georgedouzas/sports-betting/commit/6f73027865148516b53b780ae0cf23c234415d94) by georgedouzas).
+- Read long-format snapshots and derive schemas ([5f64d6a](https://github.com/georgedouzas/sports-betting/commit/5f64d6a56295de03a5e713dc37ec99ed8619c44a) by georgedouzas).
+- Simplify comments and constants ([e6f6958](https://github.com/georgedouzas/sports-betting/commit/e6f695823fb422458890d20be082fec68f5e44f8) by georgedouzas).
 
 ### Tests
 
-- Flatten base tests and quiet the untyped-body note ([0394023](https://github.com/georgedouzas/sports-betting/commit/039402384349ae9f063156f3e568eafa3f75cf6f) by georgedouzas).
-- Cover long-format loader and data consumption ([ada3d57](https://github.com/georgedouzas/sports-betting/commit/ada3d578ba0ef670ce5c79191112f183d7e7232c) by georgedouzas).
+- Flatten base tests and quiet the untyped-body note ([5692618](https://github.com/georgedouzas/sports-betting/commit/56926189339a2b804f5a836d53b96e13744fbd67) by georgedouzas).
+- Cover long-format loader and data consumption ([025cbcc](https://github.com/georgedouzas/sports-betting/commit/025cbcc8342bf1781ab07ce02c147df7c4d29744) by georgedouzas).
 
 ### Chore
 
-- Update copier template ([f20166e](https://github.com/georgedouzas/sports-betting/commit/f20166e62a9db273638c90b9f47307792690ddc8) by georgedouzas).
-- Add spec-kit tooling and in-play feature specs ([10def40](https://github.com/georgedouzas/sports-betting/commit/10def406faa20fd0a66aa2eaf8af5e1717a671c6) by georgedouzas).
-- Configure bandit for the checks session ([d619a52](https://github.com/georgedouzas/sports-betting/commit/d619a5241904ac31003a6fb9056236c40493fe7a) by georgedouzas).
-- Change to correct template name ([bb3c1de](https://github.com/georgedouzas/sports-betting/commit/bb3c1dee0071e488b309ff2755d28566321c2864) by georgedouzas).
-- Do not build source distribution ([93c9b50](https://github.com/georgedouzas/sports-betting/commit/93c9b50bd169c865d20d2e4494e36d2af294a72a) by georgedouzas).
+- Release 0.13.0 ([d069bd1](https://github.com/georgedouzas/sports-betting/commit/d069bd14b3d7027fc74690eaac448ad90690b56e) by georgedouzas).
+- Update copier template ([1609d73](https://github.com/georgedouzas/sports-betting/commit/1609d732e474cfcaae23086a780fac8350bf29e9) by georgedouzas).
+- Add spec-kit tooling and in-play feature specs ([222f2fb](https://github.com/georgedouzas/sports-betting/commit/222f2fb773b1e53d7651933d38287685e0c1c8bd) by georgedouzas).
+- Configure bandit for the checks session ([61d3c12](https://github.com/georgedouzas/sports-betting/commit/61d3c12bd23ed3f138c7b6e1797bf3873ebc7fa8) by georgedouzas).
+- Change to correct template name ([eb8a572](https://github.com/georgedouzas/sports-betting/commit/eb8a5725fc397485199402515ca2566d706faa9f) by georgedouzas).
+- Do not build source distribution ([2fc301b](https://github.com/georgedouzas/sports-betting/commit/2fc301b2d1c0d40ed28a879d7f6c3f00904340ad) by georgedouzas).
 
 ## [0.12.1](https://github.com/georgedouzas/sports-betting/releases/tag/0.12.1) - 2025-12-07
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -182,7 +182,7 @@ def release(session: nox.Session) -> None:
     Arguments:
         session: The nox session.
     """
-    session.run('pdm', 'install', '-dG', 'changelog', '-dG', 'release', '--no-default', external=True)
+    session.run('pdm', 'install', '-dG', 'changelog', '--no-default', external=True)
     from git_changelog.cli import build_and_render  # noqa: PLC0415
 
     changelog, _ = build_and_render(**CHANGELOG_ARGS)
@@ -202,12 +202,9 @@ def release(session: nox.Session) -> None:
     session.run('gh', 'pr', 'create', '--base', 'main', external=True)
     session.run('gh', 'pr', 'merge', '--rebase', '--delete-branch', external=True)
 
-    # Create tag
+    # Create and push the tag, which triggers the release workflow to build and
+    # publish the distribution to GitHub and PyPI.
     session.run('git', 'checkout', 'main', external=True)
     session.run('git', 'pull', '--rebase', external=True)
     session.run('git', 'tag', version, external=True)
     session.run('git', 'push', '--tags', external=True)
-
-    # Build and upload artifacts
-    session.run('pdm', 'build', '--no-sdist', external=True)
-    session.run('twine', 'upload', '--skip-existing', 'dist/*')

--- a/noxfile.py
+++ b/noxfile.py
@@ -199,7 +199,7 @@ def release(session: nox.Session) -> None:
     session.run('git', 'push', '-u', 'origin', f'release_{version}', external=True)
 
     # Create and merge PR from release branch to main
-    session.run('gh', 'pr', 'create', '--base', 'main', external=True)
+    session.run('gh', 'pr', 'create', '--base', 'main', '--fill', external=True)
     session.run('gh', 'pr', 'merge', '--rebase', '--delete-branch', external=True)
 
     # Create and push the tag, which triggers the release workflow to build and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["pdm-pep517"]
-build-backend = "pdm.pep517.api"
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
 
 [project]
 name = "sports_betting"
@@ -57,9 +57,12 @@ gui = [
     "reflex==0.7.0",
     "reflex-ag-grid>=0.0.10",
 ]
-[tool.pdm]
-version = {source = "scm"}
-build = {package-dir = "src", editable-backend = "editables"}
+[tool.pdm.version]
+source = "scm"
+
+[tool.pdm.build]
+package-dir = "src"
+editable-backend = "editables"
 
 [tool.pdm.scripts]
 clean = "nox --error-on-external-run -R -s clean"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "nptyping>=2.5.0",
+    "numpy>=2.1.0",
     "pandas>=2.3.3",
     "scikit-learn>=1.6.0",
     "cloudpickle>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,9 +114,6 @@ tests = [
 changelog = [
     "git-changelog>=2.5.2",
 ]
-release = [
-    "twine>=5.1.1",
-]
 
 [tool.black]
 line-length = 120

--- a/src/sportsbet/__init__.py
+++ b/src/sportsbet/__init__.py
@@ -12,14 +12,14 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-from nptyping import Bool, Float, Int, NDArray, Shape
+from numpy.typing import NDArray
 
 Param = dict[str, Any]
 ParamGrid = dict[str, list[Any]] | list[dict[str, list[Any]]]
 TrainData = tuple[pd.DataFrame, pd.DataFrame | None, pd.DataFrame]
 FixturesData = tuple[pd.DataFrame, None, pd.DataFrame]
-Data = NDArray[Shape['*, *'], Float]
-BoolData = NDArray[Shape['*, *'], Bool]
-Indices = NDArray[Shape['*, *'], Int]
+Data = NDArray[np.float64]
+BoolData = NDArray[np.bool_]
+Indices = NDArray[np.intp]
 Schema = list[tuple[str, type[int] | type[float] | type[object] | type[np.datetime64]]]
 OutputsMapping = dict[str, dict[str, Callable[..., pd.DataFrame]]]

--- a/src/sportsbet/evaluation/_base.py
+++ b/src/sportsbet/evaluation/_base.py
@@ -12,7 +12,7 @@ from typing import ClassVar, Self
 import cloudpickle
 import numpy as np
 import pandas as pd
-from nptyping import NDArray, Shape, String
+from numpy.typing import NDArray
 from sklearn.base import BaseEstimator, ClassifierMixin, MultiOutputMixin
 from sklearn.exceptions import NotFittedError
 from sklearn.utils import check_consistent_length, check_scalar
@@ -90,7 +90,7 @@ class BaseBettor(MultiOutputMixin, ClassifierMixin, BaseEstimator, metaclass=ABC
         self.init_cash = init_cash
         self.stake = stake
 
-    def _get_feature_names_odds(self: Self, O: pd.DataFrame) -> NDArray[Shape['*'], String]:  # noqa: F722
+    def _get_feature_names_odds(self: Self, O: pd.DataFrame) -> NDArray[np.str_]:
         # One odds column per selected market base, at the latest snapshot, ordered to match
         # `betting_markets_` so positional alignment with `Y` holds.
         columns = list(O.columns)

--- a/src/sportsbet/evaluation/_model_selection.py
+++ b/src/sportsbet/evaluation/_model_selection.py
@@ -12,7 +12,7 @@ from typing import Any, Self
 import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed
-from nptyping import Float, NDArray, Shape
+from numpy.typing import NDArray
 from sklearn import get_config, set_config
 from sklearn.exceptions import NotFittedError
 from sklearn.model_selection import GridSearchCV, TimeSeriesSplit
@@ -399,7 +399,7 @@ class BettorGridSearchCV(GridSearchCV, BaseBettor):
             estimator: BaseBettor,
             X: pd.DataFrame,
             Y: pd.DataFrame,
-            sample_weight: NDArray[Shape['*'], Float] | None = None,  # noqa: F722
+            sample_weight: NDArray[np.float64] | None = None,
             **kwargs: dict[str, Any],
         ) -> float:
             Y = Y[estimator.feature_names_out_]


### PR DESCRIPTION
- **fix: Drop nptyping so numpy can move to 2.x**
- **build: Let CI be the single release publisher**
- **build: Migrate to pdm-backend and auto-fill the release PR**
- **chore: Release 0.13.1**
