### PR TITLE
ci: Fix the release/CI workflow interplay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - '**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - '**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   checks:

--- a/noxfile.py
+++ b/noxfile.py
@@ -207,4 +207,4 @@ def release(session: nox.Session) -> None:
     session.run('git', 'checkout', 'main', external=True)
     session.run('git', 'pull', '--rebase', external=True)
     session.run('git', 'tag', version, external=True)
-    session.run('git', 'push', '--tags', external=True)
+    session.run('git', 'push', 'origin', version, external=True)


### PR DESCRIPTION
Two workflow fixes that were accidentally committed to the local main branch:

- CI no longer runs on tag pushes (only the release workflow does)
- The release pushes only its own tag, and the CI token is read-only