### PR TITLE
build: Sync development to main after a release

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -208,3 +208,8 @@ def release(session: nox.Session) -> None:
     session.run('git', 'pull', '--rebase', external=True)
     session.run('git', 'tag', version, external=True)
     session.run('git', 'push', 'origin', version, external=True)
+
+    # Sync the development branch to the released main so they do not diverge.
+    session.run('git', 'checkout', 'development', external=True)
+    session.run('git', 'reset', '--hard', 'main', external=True)
+    session.run('git', 'push', '--force-with-lease', 'origin', 'development', external=True)


### PR DESCRIPTION
Add a final step to the release nox session that resets development to the released main and force-pushes it, so the branches stop diverging after each rebase-merge release.